### PR TITLE
OnScriptCash is not implemented

### DIFF
--- a/filterscript.new
+++ b/filterscript.new
@@ -316,11 +316,6 @@ public OnPlayerWeaponShot(playerid, WEAPON:weaponid, BULLET_HIT_TYPE:hittype, hi
 	return 1;
 }
 
-public OnScriptCash(playerid, amount, source)
-{
-	return 1;
-}
-
 public OnPlayerClickMap(playerid, Float:fX, Float:fY, Float:fZ)
 {
 	return 1;

--- a/gamemode.new
+++ b/gamemode.new
@@ -333,11 +333,6 @@ public OnPlayerWeaponShot(playerid, WEAPON:weaponid, BULLET_HIT_TYPE:hittype, hi
 	return 1;
 }
 
-public OnScriptCash(playerid, amount, source)
-{
-	return 1;
-}
-
 public OnPlayerClickMap(playerid, Float:fX, Float:fY, Float:fZ)
 {
 	return 1;


### PR DESCRIPTION
There is now a callback declaration for OnScriptCash which is not implemented (it doesn't even have any rpc to be enabled anyhow). So, it's obviously non-working thing which was already removed from omp-stdlib (its forwarding) and it's better to omit it here as well, until omp client comes to release and maybe then add the actual feature.